### PR TITLE
Update Releases/installation.md

### DIFF
--- a/Releases/Installation.md
+++ b/Releases/Installation.md
@@ -15,7 +15,7 @@
 
 * Visit `about:debugging` from the URL bar.
 * Click on `Load Temporary Add-on`
-* Select `manifest.json` from `Releases/StarFOSS/v1/firefox/`
+* Select `manifest.json` from `Releases/firefox/`
 
 ### Voila !! :tada:
 ---


### PR DESCRIPTION
Current guide contains a non-existent path to manifest.json.
This commit updates it with the correct installation path for Firefox.

Also, here's an instructional image to replace the previous one:
![instructions](https://user-images.githubusercontent.com/34815179/46293510-5de56c80-c5b1-11e8-8975-95d314383ca2.png)


